### PR TITLE
Only create directories when prometheus is going to be installed.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,6 +38,7 @@
     - "{{ prometheus_rules_dir }}"
     - "{{ prometheus_snmp_exporter_config_dir }}"
     - "{{ prometheus_blackbox_exporter_config_dir }}"
+  when: prometheus_install
 
 - name: Install Prometheus
   include: install-prometheus.yml


### PR DESCRIPTION
No need for them on a node_exporter only install